### PR TITLE
Modified ip_ranges to accept no arguments

### DIFF
--- a/lib/piculet/dsl/permission.rb
+++ b/lib/piculet/dsl/permission.rb
@@ -4,6 +4,7 @@ module Piculet
       class SecurityGroup
         class Permissions
           class Permission
+            include Logger::ClientHelper
             def initialize(security_group, direction, protocol_prot_range, &block)
               @security_group = security_group
               @direction = direction
@@ -23,7 +24,7 @@ module Piculet
             private
             def ip_ranges(*values)
               if values.empty?
-                raise ArgumentError, "SecurityGroup `#{@security_group}`: #{@direction}: #{@protocol_prot_range}: `ip_ranges`: wrong number of arguments (0 for 1..)"
+                log(:warn, "SecurityGroup `#{@security_group}`: #{@direction}: #{@protocol_prot_range}: `ip_ranges` contains no ip ranges", :yellow)
               end
 
               values.each do |ip_range|


### PR DESCRIPTION
Allows passing function calls to ip_ranges without checking for empty results
Still generates warnings

I'm using cross-VPC rules so no security groups, only IP ranges.
As a result, I sometimes have rules with "no sources" (no VMs matching that specific role) and they fail.
This fix allows `ip_ranges` to accept no arguments which generates a warning and might create an empty permission (which gets deleted).
Note that a group with `ip_ranges=[]` is identical to the empty group thanks to the [normalization](https://github.com/winebarrel/piculet/blob/master/lib/piculet/wrapper/permission.rb#L66)

If you think this is wrong, please LMK and we can try and find out if there's an agreeable way to solve my issues