### PR TITLE
Raise exception if ip_ranges or groups have duplicate values.

### DIFF
--- a/lib/piculet/dsl/permission.rb
+++ b/lib/piculet/dsl/permission.rb
@@ -38,6 +38,10 @@ module Piculet
                 end
               end
 
+              if values.size != values.uniq.size
+                raise "SecurityGroup `#{@security_group}\: #{@direction}: #{@protocol_prot_range}: `ip_ranges`: duplicate ip ranges"
+              end
+
               @result.ip_ranges = values
             end
 
@@ -50,6 +54,10 @@ module Piculet
                 unless [String, Array].any? {|i| group.kind_of?(i) }
                   raise "SecurityGroup `#{@security_group}`: #{@direction}: #{@protocol_prot_range}: `groups`: invalid type: #{group}"
                 end
+              end
+
+              if values.size != values.uniq.size
+                raise "SecurityGroup `#{@security_group}\: #{@direction}: #{@protocol_prot_range}: `groups`: duplicate groups"
               end
 
               @result.groups = values


### PR DESCRIPTION
Adding validation codes for permission.

# Problem

At first, apply the following DSL.
```
ec2 "vpc-XXXXXXXX" do
  security_group "default" do
    description "default VPC security group"

    ingress do
      permission :tcp, 443..443 do
        ip_ranges("192.0.2.1/32")   

        groups("default")
      end 
    end 

    egress do
      permission :any do
        ip_ranges("0.0.0.0/0")   
      end 
    end 
  end 
end
```
And apply the following DSL.
```
ec2 "vpc-XXXXXXXX" do
  security_group "default" do
    description "default VPC security group"

    ingress do
      permission :tcp, 443..443 do
        ip_ranges("192.0.2.1/32", "192.0.2.1/32")   

        groups("default", "default")   
      end 
    end 

    egress do
      permission :any do
        ip_ranges("0.0.0.0/0")   
      end 
    end 
  end 
end
```

Then piculet shows following messages, but do nothing.
```
Apply `Groupfile` to SecurityGroup
Update Permission: vpc-XXXXXXXX > default(ingress) > tcp 443..443
No change
```