### PR TITLE
Exclude tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Usage: piculet [options]
     -f, --file FILE
     -n, --names SG_LIST
     -x, --exclude SG_LIST
+    -t, --exclude_tag TAGS
         --ec2s VPC_IDS
         --dry-run
     -e, --export

--- a/bin/piculet
+++ b/bin/piculet
@@ -40,6 +40,7 @@ ARGV.options do |opt|
     opt.on('-f', '--file FILE')                     {|v| file                         = v           }
     opt.on('-n', '--names SG_LIST', Array)          {|v| options[:sg_names]           = v           }
     opt.on('-x', '--exclude SG_LIST', Array)        {|v| options[:exclude_sgs]        = v           }
+    opt.on('-t', '--exclude_tag TAGS', Array)       {|v| options[:exclude_tags]       = v           }
     opt.on('',   '--ec2s VPC_IDS', Array)           {|v| options[:ec2s]               = v           }
     opt.on('',   '--dry-run')                       {|v| options[:dry_run]            = true        }
     opt.on('-e', '--export')                        {|v| mode                         = :export     }


### PR DESCRIPTION
1. Move filtering to a separate function (DRY)
2. Allowing ignoring (excluding) groups that contain a nonempty value in a specific tag. Multiple tags can be specified.