### PR TITLE
ip-range cidr check (e.g 10.0.0.130/25 > .128/25

### DIFF
--- a/lib/piculet/dsl/permission.rb
+++ b/lib/piculet/dsl/permission.rb
@@ -1,3 +1,4 @@
+require 'ipaddr'
 module Piculet
   class DSL
     class EC2
@@ -43,6 +44,15 @@ module Piculet
 
                 unless ip.split('.').all? {|i| (0..255).include?(i.to_i) } and (0..32).include?(range.to_i)
                   raise "SecurityGroup `#{@security_group}`: #{@direction}: #{@protocol_prot_range}: `ip_ranges`: invalid ip range: #{ip_range}"
+                end
+
+                begin
+                  ipaddr = IPAddr.new(ip_range)
+                  unless ip == ipaddr.to_s
+                    raise "SecurityGroup `#{@security_group}`: #{@direction}: #{@protocol_prot_range}: `ip_ranges`: invalid ip range: #{ip_range} correct #{ipaddr.to_s}/#{range}"
+                  end
+                rescue => e
+                  raise e
                 end
               end
 


### PR DESCRIPTION
The piculet  allows not correct cidr (e.g 10.0.0.130/25), but AWS transform it to 10.0.0.128/25 automatically.  So, When Groupfile contains not correct cidr and after apply it,  piculet anytime detect delta.